### PR TITLE
Refactored package.json tweego builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "lint": "gulp lint",
     "lint-js": "gulp lint",
     "lint-css": "gulp validate",
-    "build": "gulp build && tweego -f $npm_package_config_format -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "testmode": "gulp build && tweego -f $npm_package_config_format -t -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "tweegobuild": "tweego -f $npm_package_config_format -m src/modules/ -o dist/index.html project",
-    "build-win": "gulp build && tweego -f %npm_package_config_format% -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "testmode-win": "gulp build && tweego -f %npm_package_config_format% -t -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "tweegobuild-win": "tweego -f %npm_package_config_format% -m src/modules/ -o dist/index.html project"
+    "build": "gulp build && tweego -f $npm_package_config_format -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "testmode": "gulp build && tweego -f $npm_package_config_format -t -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "tweegobuild": "tweego -f $npm_package_config_format -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project",
+    "build-win": "gulp build && tweego -f %npm_package_config_format% -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "testmode-win": "gulp build && tweego -f %npm_package_config_format% -t -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "tweegobuild-win": "tweego -f %npm_package_config_format% -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project"
   },
   "keywords": [
     "twine",


### PR DESCRIPTION
Added  ```--head=src/modules/head-content.html``` to tweego build scripts in package.json. 

The current ```-o src/modules/``` option does not add any html content to the output file. The [tweego docs](https://www.motoslave.net/tweego/docs/#usage-options) indicate this is only used for adding the appropriate tags for css, js, and various fonts to the head tag. --head is required for that.